### PR TITLE
Remove host path

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Tools for inspection of various things in PostgreSQL servers.
 # Installation
 
 To install this package, first make sure that you have a recent
-version of ``setuptools``
+version of ``setuptools``.
 
 ```
 pip install --upgrade setuptools
@@ -31,3 +31,11 @@ graph to only the nodes involved in a deadlock.
 To print the subgraph(s) involving a deadlock, all edges that represents
 locks that are not granted are collected and the induced subgraph
 consisting of the vertices attached to those edges are built.
+
+If you have a source install, socket files are placed under `/tmp` so
+you can read from this by providing the directory as `--host` value
+and have `PGDATA` set correctly.
+
+```
+mk-lock-graph --host=/tmp
+```

--- a/src/pgtools/cli/lock_graph.py
+++ b/src/pgtools/cli/lock_graph.py
@@ -51,7 +51,7 @@ def main():
     args = parse_arguments(main.__doc__)
     conn = psycopg2.connect(dbname=args.dbname, user=args.user,
                             password=(None if args.password is None else args.password),
-                            host=('/tmp' if args.host is None else args.host))
+                            host=args.host)
     lgraph = LockGraph()
     lgraph.build(conn)
     lgraph.apply_filters(args.filters)


### PR DESCRIPTION
The path `/tmp` is based on using a temporary install, which means that it does not work for normal installs. Users can read from a temporary install by providing `/tmp` to the `--host` option.